### PR TITLE
Relax plutus-core bounds on cryptonite

### DIFF
--- a/_sources/plutus-core/1.0.0.0/meta.toml
+++ b/_sources/plutus-core/1.0.0.0/meta.toml
@@ -9,3 +9,7 @@ subdir = 'plutus-core'
 [[revisions]]
   number = 2
   timestamp = 2022-09-07T12:30:34Z
+
+[[revisions]]
+  number = 3
+  timestamp = 2022-09-07T13:32:39Z

--- a/_sources/plutus-core/1.0.0.0/revisions/3.cabal
+++ b/_sources/plutus-core/1.0.0.0/revisions/3.cabal
@@ -1,0 +1,729 @@
+cabal-version: 3.0
+name: plutus-core
+version: 1.0.0.0
+license: Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+maintainer: michael.peyton-jones@iohk.io
+author: Plutus Core Team
+synopsis: Language library for Plutus Core
+description:
+    Pretty-printer, parser, and typechecker for Plutus Core.
+category: Language, Plutus
+build-type: Simple
+extra-doc-files: README.md
+extra-source-files:
+    cost-model/data/builtinCostModel.json
+    cost-model/data/cekMachineCosts.json
+    cost-model/data/benching.csv
+    cost-model/data/*.R
+    plutus-core/test/CostModelInterface/defaultCostModelParams.json
+
+source-repository head
+    type: git
+    location: https://github.com/input-output-hk/plutus
+
+common lang
+    default-language: Haskell2010
+    default-extensions: ExplicitForAll FlexibleContexts ScopedTypeVariables
+                        DeriveGeneric StandaloneDeriving DeriveLift
+                        GeneralizedNewtypeDeriving DeriveFunctor DeriveFoldable
+                        DeriveTraversable DerivingStrategies DerivingVia
+                        ImportQualifiedPost
+    ghc-options: -Wall -Wnoncanonical-monad-instances
+                 -Wincomplete-uni-patterns -Wincomplete-record-updates
+                 -Wredundant-constraints -Widentities -Wunused-packages
+                 -Wmissing-deriving-strategies
+
+library
+    import: lang
+    exposed-modules:
+        PlutusCore
+        PlutusCore.Check.Normal
+        PlutusCore.Check.Scoping
+        PlutusCore.Check.Uniques
+        PlutusCore.Check.Value
+        PlutusCore.Builtin
+        PlutusCore.Builtin.Debug
+        PlutusCore.Builtin.Elaborate
+        PlutusCore.Builtin.Emitter
+        PlutusCore.Core
+        PlutusCore.Data
+        PlutusCore.DataFilePaths
+        PlutusCore.DeBruijn
+        PlutusCore.Default
+        PlutusCore.Error
+        PlutusCore.Evaluation.Machine.BuiltinCostModel
+        PlutusCore.Evaluation.Machine.Ck
+        PlutusCore.Evaluation.Machine.CostModelInterface
+        PlutusCore.Evaluation.Machine.ExBudget
+        PlutusCore.Evaluation.Machine.ExMemory
+        PlutusCore.Evaluation.Machine.Exception
+        PlutusCore.Evaluation.Machine.MachineParameters
+        PlutusCore.Evaluation.Result
+        PlutusCore.Examples.Builtins
+        PlutusCore.Examples.Data.Data
+        PlutusCore.Examples.Data.InterList
+        PlutusCore.Examples.Data.List
+        PlutusCore.Examples.Data.Pair
+        PlutusCore.Examples.Data.Shad
+        PlutusCore.Examples.Data.TreeForest
+        PlutusCore.Examples.Data.Vec
+        PlutusCore.Examples.Everything
+        PlutusCore.Flat
+        PlutusCore.FsTree
+        PlutusCore.Mark
+        PlutusCore.MkPlc
+        PlutusCore.Name
+        PlutusCore.Normalize
+        PlutusCore.Normalize.Internal
+        PlutusCore.Parser
+        PlutusCore.Pretty
+        PlutusCore.Quote
+        PlutusCore.Rename
+        PlutusCore.Rename.Internal
+        PlutusCore.Rename.Monad
+        PlutusCore.StdLib.Data.Bool
+        PlutusCore.StdLib.Data.ChurchNat
+        PlutusCore.StdLib.Data.Data
+        PlutusCore.StdLib.Data.Function
+        PlutusCore.StdLib.Data.Integer
+        PlutusCore.StdLib.Data.List
+        PlutusCore.StdLib.Data.Nat
+        PlutusCore.StdLib.Data.Pair
+        PlutusCore.StdLib.Data.ScottList
+        PlutusCore.StdLib.Data.ScottUnit
+        PlutusCore.StdLib.Data.Sum
+        PlutusCore.StdLib.Data.Unit
+        PlutusCore.StdLib.Everything
+        PlutusCore.StdLib.Meta
+        PlutusCore.StdLib.Meta.Data.Function
+        PlutusCore.StdLib.Meta.Data.Tuple
+        PlutusCore.StdLib.Type
+        PlutusCore.Subst
+
+        PlutusIR
+        PlutusIR.Analysis.RetainedSize
+        PlutusIR.Compiler
+        PlutusIR.Compiler.Definitions
+        PlutusIR.Compiler.Names
+        PlutusIR.Core
+        PlutusIR.Core.Instance
+        PlutusIR.Core.Instance.Flat
+        PlutusIR.Core.Instance.Pretty
+        PlutusIR.Core.Instance.Scoping
+        PlutusIR.Core.Plated
+        PlutusIR.Core.Type
+        PlutusIR.Error
+        PlutusIR.Mark
+        PlutusIR.MkPir
+        PlutusIR.Parser
+        PlutusIR.Purity
+        PlutusIR.Subst
+        PlutusIR.Transform.Beta
+        PlutusIR.Transform.DeadCode
+        PlutusIR.Transform.Inline
+        PlutusIR.Transform.LetFloat
+        PlutusIR.Transform.LetMerge
+        PlutusIR.Transform.RecSplit
+        PlutusIR.Transform.NonStrict
+        PlutusIR.Transform.Rename
+        PlutusIR.Transform.Substitute
+        PlutusIR.Transform.ThunkRecursions
+        PlutusIR.Transform.Unwrap
+        PlutusIR.TypeCheck
+
+        UntypedPlutusCore
+        UntypedPlutusCore.DeBruijn
+        UntypedPlutusCore.Evaluation.Machine.Cek
+        UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+        UntypedPlutusCore.Parser
+        UntypedPlutusCore.Rename
+        UntypedPlutusCore.MkUPlc
+        UntypedPlutusCore.Check.Scope
+        UntypedPlutusCore.Check.Uniques
+        UntypedPlutusCore.Core
+        UntypedPlutusCore.Core.Type
+
+        Crypto
+        Data.ByteString.Hash
+        Data.SatInt
+        Prettyprinter.Custom
+        ErrorCode
+        PlutusPrelude
+        Universe
+    hs-source-dirs:
+        plutus-core/src
+        plutus-core/stdlib
+        plutus-core/examples
+        plutus-ir/src
+        untyped-plutus-core/src
+        prelude
+        common
+    other-modules:
+        PlutusCore.Analysis.Definitions
+        PlutusCore.Builtin.HasConstant
+        PlutusCore.Builtin.KnownKind
+        PlutusCore.Builtin.KnownType
+        PlutusCore.Builtin.KnownTypeAst
+        PlutusCore.Builtin.Meaning
+        PlutusCore.Builtin.Polymorphism
+        PlutusCore.Builtin.Runtime
+        PlutusCore.Builtin.TestKnown
+        PlutusCore.Builtin.TypeScheme
+        PlutusCore.Core.Instance
+        PlutusCore.Core.Instance.Eq
+        PlutusCore.Core.Instance.Pretty
+        PlutusCore.Core.Instance.Pretty.Classic
+        PlutusCore.Core.Instance.Pretty.Common
+        PlutusCore.Core.Instance.Pretty.Default
+        PlutusCore.Core.Instance.Pretty.Plc
+        PlutusCore.Core.Instance.Pretty.Readable
+        PlutusCore.Core.Instance.Recursive
+        PlutusCore.Core.Instance.Scoping
+        PlutusCore.Core.Plated
+        PlutusCore.Core.Type
+        PlutusCore.DeBruijn.Internal
+        PlutusCore.Default.Builtins
+        PlutusCore.Default.Universe
+        PlutusCore.Eq
+        PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+        PlutusCore.InlineUtils
+        PlutusCore.Parser.ParserCommon
+        PlutusCore.Pretty.Classic
+        PlutusCore.Pretty.ConfigName
+        PlutusCore.Pretty.ConfigName
+        PlutusCore.Pretty.Default
+        PlutusCore.Pretty.Plc
+        PlutusCore.Pretty.PrettyConst
+        PlutusCore.Pretty.Readable
+        PlutusCore.Pretty.Utils
+        PlutusCore.Size
+        PlutusCore.TypeCheck
+        PlutusCore.TypeCheck.Internal
+
+        PlutusIR.Analysis.Dependencies
+        PlutusIR.Analysis.Size
+        PlutusIR.Analysis.Usages
+        PlutusIR.Compiler.Datatype
+        PlutusIR.Compiler.Error
+        PlutusIR.Compiler.Let
+        PlutusIR.Compiler.Lower
+        PlutusIR.Compiler.Provenance
+        PlutusIR.Compiler.Recursion
+        PlutusIR.Compiler.Types
+        PlutusIR.Normalize
+        PlutusIR.TypeCheck.Internal
+
+        UntypedPlutusCore.Analysis.Definitions
+        UntypedPlutusCore.Analysis.Usages
+        UntypedPlutusCore.Core.Instance
+        UntypedPlutusCore.Core.Instance.Eq
+        UntypedPlutusCore.Core.Instance.Flat
+        UntypedPlutusCore.Core.Instance.Pretty
+        UntypedPlutusCore.Core.Instance.Pretty.Classic
+        UntypedPlutusCore.Core.Instance.Pretty.Default
+        UntypedPlutusCore.Core.Instance.Pretty.Plc
+        UntypedPlutusCore.Core.Instance.Pretty.Readable
+        UntypedPlutusCore.Core.Instance.Recursive
+        UntypedPlutusCore.Core.Plated
+        UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+        UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
+        UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
+        UntypedPlutusCore.Mark
+        UntypedPlutusCore.Rename.Internal
+        UntypedPlutusCore.Simplify
+        UntypedPlutusCore.Size
+        UntypedPlutusCore.Subst
+        UntypedPlutusCore.Transform.ForceDelay
+        UntypedPlutusCore.Transform.Inline
+
+        Data.Aeson.Flatten
+        Data.Aeson.THReader
+        Data.Functor.Foldable.Monadic
+        Universe.Core
+        GHC.Natural.Extras
+    build-depends:
+        aeson                  >= 2.0.3.0   && <2.1
+      , algebraic-graphs       >= 0.3       && <0.7
+      , array                  >= 0.5.4.0   && <0.6
+      , barbies                >= 2.0.3.1   && <2.1
+      , base                   >= 4.9       && <5
+      , bimap                  >= 0.4.0     && <0.5
+      , bytestring             >= 0.10.12.0 && <0.11
+      , cardano-crypto         >= 1.1.0     && <1.2
+      , cassava                >= 0.5.2.0   && <0.6
+      , cborg                  >= 0.2.6.0   && <0.3
+      , composition-prelude    >= 1.1.0.1   && <3.1
+      , containers             >= 0.6.2.1   && <0.7
+      , cryptonite             >= 0.29      && <0.31
+      , data-default-class     >= 0.1.2.0   && <0.2
+      , deepseq                >= 1.4.4.0   && <1.5
+      , dependent-sum-template >= 0.1.0.3   && <0.2
+      , deriving-aeson         >= 0.2.3     && <0.3
+      , deriving-compat        >= 0.5.9     && <0.6
+      , dlist                  >= 1.0       && <1.1
+      , dom-lt                 >= 0.2.3     && <0.3
+      , exceptions             >= 0.10.4    && <0.11
+      , extra                  >= 1.7.10    && <1.8
+      , filepath               >= 1.4.2.1   && <1.5
+      , flat                   >= 0.4.4     && <0.5
+      , ghc-prim               >= 0.6.1     && <0.7
+      , hashable               >= 1.3.5.0   && <1.4
+      , hedgehog               >= 1.0       && <1.2
+      , int-cast               >= 0.2.0.0   && <0.3
+      , integer-gmp            >= 1.0.3.0   && <1.1
+      , lens                   >= 4.19.2    && <4.20
+      , megaparsec             >= 9.2.0     && <9.3
+      , mmorph                 >= 1.2.0     && <1.3
+      , monoidal-containers    >= 0.6.2.0   && <0.7
+      , mtl                    >= 2.2.2     && <2.3
+      , parser-combinators     >= 0.4.0     && <1.4
+      , prettyprinter          >= 1.1.0.1   && <1.8
+      , prettyprinter-configurable
+      , primitive              >= 0.7.3.0   && <0.8
+      , recursion-schemes      >= 5.2       && <5.3
+      , secp256k1-haskell      >= 0.6.0     && <0.7
+      , semigroupoids          >= 5.3.4     && <5.4
+      , semigroups             >= 0.19.1    && <0.21
+      , serialise              >= 0.2.4.0   && <0.3
+      , some                   >= 1.0.2     && <1.1
+      , template-haskell       >= 2.16.0.0  && <2.17
+      , th-compat              >= 0.1.3     && <0.2
+      , text                   >= 1.2.4.1   && <1.3
+      , th-lift                >= 0.8.2     && <0.9
+      , th-lift-instances      >= 0.1.19    && <0.2
+      , th-utilities           >= 0.2.4.1   && <0.3
+      , time                   >= 1.9.3     && <1.10
+      , transformers           >= 0.5.6.2   && <0.6
+      , unordered-containers   >= 0.2.16.0  && <0.3
+      , witherable             >= 0.4.2     && <0.5
+      , word-array
+      , cardano-crypto-class   >= 2.0.0     && <2.1
+      , index-envs
+
+-- could split this up if we split up the main library for UPLC/PLC/PIR
+library plutus-core-testlib
+    import: lang
+    visibility: public
+    hs-source-dirs: testlib
+    exposed-modules:
+        PlutusCore.Test
+        PlutusCore.Generators
+        PlutusCore.Generators.AST
+        PlutusCore.Generators.Interesting
+        PlutusCore.Generators.NEAT.Common
+        PlutusCore.Generators.NEAT.Spec
+        PlutusCore.Generators.NEAT.Term
+        PlutusCore.Generators.NEAT.Type
+        PlutusCore.Generators.Test
+
+        PlutusIR.Test
+        PlutusIR.Generators.AST
+
+        Test.Tasty.Extras
+    other-modules:
+        PlutusCore.Generators.Internal.Denotation
+        PlutusCore.Generators.Internal.Dependent
+        PlutusCore.Generators.Internal.Entity
+        PlutusCore.Generators.Internal.TypeEvalCheck
+        PlutusCore.Generators.Internal.TypedBuiltinGen
+        PlutusCore.Generators.Internal.Utils
+    build-depends:
+        base           >= 4.9       && <5
+      , bifunctors     >= 5.5.7     && <5.6
+      , bytestring     >= 0.10.12.0 && <0.11
+      , containers     >= 0.6.2.1   && <0.7
+      , dependent-map  >= 0.4.0.0   && <0.5
+      , filepath       >= 1.4.2.1   && <1.5
+      , ghc-prim       >= 0.6.1     && <0.7
+      , hedgehog       >= 1.0       && <1.2
+      , integer-gmp    >= 1.0.3.0   && <1.1
+      , lazy-search    >= 0.1.2.1   && <0.2
+      , lens           >= 4.19.2    && <4.20
+      , megaparsec     >= 9.2.0     && <9.3
+      , mmorph         >= 1.2.0     && <1.3
+      , mtl            >= 2.2.2     && <2.3
+      , plutus-core
+      , prettyprinter  >= 1.1.0.1   && <1.8
+      , prettyprinter-configurable
+      , size-based     >= 0.1.2.0   && <0.2
+      , some           >= 1.0.2     && <1.1
+      , Stream         >= 0.4.7.2   && <0.5
+      , tasty          >= 1.4.2.1   && <1.5
+      , tasty-golden   >= 2.3.5     && <2.4
+      , tasty-hedgehog >= 1.1.0.0   && <1.2
+      , tasty-hunit    >= 0.10.0.3  && <0.11
+      , text           >= 1.2.4.1   && <1.3
+      , transformers   >= 0.5.6.2   && <0.6
+
+test-suite satint-test
+  import: lang
+  type:              exitcode-stdio-1.0
+  main-is:           TestSatInt.hs
+  ghc-options:       -Wall
+  build-depends:     base >=4.9 && <5,
+                     test-framework,
+                     test-framework-hunit,
+                     test-framework-quickcheck2,
+                     HUnit,
+                     QuickCheck,
+                     plutus-core
+  default-language:  Haskell2010
+  hs-source-dirs:    plutus-core/satint-test
+
+test-suite plutus-core-test
+    import: lang
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    hs-source-dirs: plutus-core/test
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N
+    other-modules:
+        Check.Spec
+        CostModelInterface.Spec
+        Evaluation.Machines
+        Evaluation.Spec
+        Names.Spec
+        Normalization.Check
+        Normalization.Type
+        Pretty.Readable
+        TypeSynthesis.Spec
+    default-language: Haskell2010
+    build-depends:
+        base -any,
+        bytestring -any,
+        containers -any,
+        filepath -any,
+        flat -any,
+        hedgehog -any,
+        plutus-core -any,
+        plutus-core-testlib -any,
+        mmorph -any,
+        mtl -any,
+        prettyprinter -any,
+        tasty -any,
+        tasty-golden -any,
+        tasty-hedgehog -any,
+        tasty-hunit -any,
+        text -any,
+        transformers -any,
+        aeson -any,
+        template-haskell -any,
+        th-lift-instances -any,
+        th-utilities -any,
+
+test-suite plutus-ir-test
+    import: lang
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    hs-source-dirs: plutus-ir/test
+    other-modules:
+        NamesSpec
+        ParserSpec
+        TransformSpec
+        TypeSpec
+    build-depends:
+        base >=4.9 && <5,
+        plutus-core -any,
+        plutus-core-testlib -any,
+        flat -any,
+        hedgehog -any,
+        megaparsec -any,
+        tasty -any,
+        tasty-hedgehog -any,
+        text -any
+
+test-suite untyped-plutus-core-test
+    import: lang
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    hs-source-dirs: untyped-plutus-core/test
+    ghc-options: -O2 -threaded -rtsopts -with-rtsopts=-N
+    other-modules:
+        Evaluation.Builtins
+        Evaluation.Builtins.Coherence
+        Evaluation.Builtins.Common
+        Evaluation.Builtins.Definition
+        Evaluation.Builtins.MakeRead
+        Evaluation.Builtins.SECP256k1
+        Evaluation.FreeVars
+        Evaluation.Golden
+        Evaluation.Machines
+        Transform.Simplify
+        DeBruijn.Common
+        DeBruijn.Scope
+        DeBruijn.Spec
+        DeBruijn.UnDeBruijnify
+    build-depends:
+        base >=4.9 && <5,
+        bytestring -any,
+        cardano-crypto-class -any,
+        hedgehog -any,
+        lens -any,
+        mtl -any,
+        plutus-core -any,
+        plutus-core-testlib -any,
+        index-envs -any,
+        prettyprinter -any,
+        pretty-show -any,
+        secp256k1-haskell -any,
+        tasty -any,
+        tasty-golden -any,
+        tasty-hedgehog -any,
+        tasty-hunit -any,
+        text -any
+
+executable plc
+    import: lang
+    main-is: plc/Main.hs
+    hs-source-dirs: executables
+    other-modules:
+        Common
+        Parsers
+    build-depends:
+        plutus-core -any,
+        plutus-core-testlib -any,
+        aeson -any,
+        base <5,
+        bytestring -any,
+        deepseq -any,
+        flat -any,
+        monoidal-containers -any,
+        mtl -any,
+        optparse-applicative -any,
+        prettyprinter -any,
+        text -any,
+        transformers -any,
+        lens -any,
+        megaparsec -any
+
+executable uplc
+    import: lang
+    main-is: uplc/Main.hs
+    hs-source-dirs: executables
+    other-modules:
+        Common
+        Parsers
+    build-depends:
+        plutus-core -any,
+        plutus-core-testlib -any,
+        aeson -any,
+        base <5,
+        bytestring -any,
+        deepseq -any,
+        flat -any,
+        monoidal-containers -any,
+        mtl -any,
+        optparse-applicative -any,
+        prettyprinter -any,
+        split -any,
+        text -any,
+        transformers -any,
+        lens -any,
+        megaparsec -any
+
+executable pir
+    import: lang
+    main-is: pir/Main.hs
+    hs-source-dirs: executables
+    other-modules:
+        Common
+        Parsers
+    build-depends:
+        plutus-core -any,
+        plutus-core-testlib -any,
+        aeson -any,
+        base <5,
+        bytestring -any,
+        flat -any,
+        lens -any,
+        deepseq -any,
+        monoidal-containers -any,
+        optparse-applicative -any,
+        mtl -any,
+        transformers -any,
+        bytestring -any,
+        containers -any,
+        prettyprinter -any,
+        cassava -any,
+        text -any,
+        megaparsec -any
+
+executable traceToStacks
+    import: lang
+    main-is: Main.hs
+    hs-source-dirs: executables/traceToStacks
+    other-modules:
+        Common
+    build-depends:
+        base >=4.9 && <5,
+        cassava -any,
+        integer-gmp -any,
+        bytestring -any,
+        optparse-applicative -any,
+        text -any,
+        vector -any,
+
+-- Tests for functions called by @traceToStacks@.
+test-suite traceToStacks-test
+    import: lang
+    type: exitcode-stdio-1.0
+    hs-source-dirs: executables/traceToStacks
+    default-language: Haskell2010
+    main-is: TestGetStacks.hs
+    other-modules:
+        Common
+    build-depends:
+        base -any,
+        bytestring -any,
+        cassava -any,
+        tasty -any,
+        tasty-hunit -any,
+        text -any,
+        vector -any,
+
+-- This runs the microbenchmarks used to generate the cost models for built-in functions,
+-- saving the results in cost-model/data/benching.csv.  It will take several hours.
+benchmark cost-model-budgeting-bench
+    import: lang
+    type: exitcode-stdio-1.0
+    main-is: Main.hs
+    other-modules:
+        Common
+        CriterionExtensions
+        Generators
+        Benchmarks.Bool
+        Benchmarks.ByteStrings
+        Benchmarks.CryptoAndHashes
+        Benchmarks.Data
+        Benchmarks.Integers
+        Benchmarks.Lists
+        Benchmarks.Misc
+        Benchmarks.Nops
+        Benchmarks.Pairs
+        Benchmarks.Strings
+        Benchmarks.Tracing
+        Benchmarks.Unit
+    hs-source-dirs: cost-model/budgeting-bench
+    default-language: Haskell2010
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    build-depends:
+        plutus-core -any,
+        base -any,
+        bytestring -any,
+        criterion -any,
+        criterion-measurement -any,
+        deepseq -any,
+        directory -any,
+        hedgehog -any,
+        mtl -any,
+        optparse-applicative -any,
+        QuickCheck -any,
+        quickcheck-instances -any,
+        random -any,
+        text -any,
+
+
+-- This reads the CSV data generated by cost-model-budgeting-bench, builds the models
+-- using R, and saces them in cost-model/data/costModel.json
+-- Benchmark sets the correct PWD and doesn't get run by `stack test`
+benchmark update-cost-model
+    import: lang
+    type: exitcode-stdio-1.0
+    main-is: UpdateCostModel.hs
+    -- cost-model-creation should be its own library, but stack + HIE really don't like sub-libraries.
+    hs-source-dirs: cost-model/create-cost-model
+    default-language: Haskell2010
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    build-depends:
+        plutus-core -any,
+        aeson-pretty -any,
+        barbies -any,
+        base -any,
+        bytestring -any,
+        cassava -any,
+        exceptions -any,
+        extra -any,
+        inline-r -any,
+        text -any,
+        vector -any
+    other-modules:
+        CostModelCreation
+
+-- The cost models for builtins are generated using R and converted into a JSON
+-- form that can later be used to construct Haskell functions.  This tests that
+-- the predictions of the Haskell version are (approximately) identical to the R
+-- ones.  This test is problematic in CI: pretending that it's a benchmark will
+-- prevent it from being run automatically but will still allow us to run it
+-- manually; `cabal bench` also sets the working directory to the root of the
+-- relevant package, which makes it easier to find the cost model data files
+-- (unlike `cabal run` for exectuables, which sets the working directory to the
+-- current shell directory).
+benchmark cost-model-test
+    import: lang
+    type: exitcode-stdio-1.0
+    main-is: TestCostModels.hs
+    other-modules: TH
+    hs-source-dirs: cost-model/test, cost-model/create-cost-model
+    default-language: Haskell2010
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    build-depends:
+        base -any,
+        plutus-core -any,
+        barbies -any,
+        bytestring -any,
+        cassava -any,
+        exceptions -any,
+        extra -any,
+        hedgehog -any,
+        inline-r -any,
+        mmorph -any,
+        template-haskell -any,
+        text -any,
+        vector -any
+    other-modules:
+        CostModelCreation
+
+library index-envs
+    import: lang
+    hs-source-dirs: index-envs/src
+    default-language: Haskell2010
+    exposed-modules:
+      Data.DeBruijnEnv
+      Data.RandomAccessList.SkewBinary
+    build-depends:
+        base       >= 4.14.1.0 && <4.15
+      , containers >= 0.6.2.1  && <0.7
+        -- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+      , ral        == 0.1
+
+benchmark index-envs-bench
+    import: lang
+    type: exitcode-stdio-1.0
+    hs-source-dirs: index-envs/bench
+    default-language: Haskell2010
+    main-is: Main.hs
+    build-depends:
+        base -any,
+        index-envs -any,
+        criterion >= 1.5.9.0,
+        random >= 1.2.0,
+        -- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+        ral == 0.1
+
+test-suite index-envs-test
+    import: lang
+    type: exitcode-stdio-1.0
+    hs-source-dirs: index-envs/test
+    default-language: Haskell2010
+    main-is: TestRAList.hs
+    build-depends:
+        base -any,
+        index-envs -any,
+        tasty -any,
+        tasty-hunit -any,
+        tasty-quickcheck -any


### PR DESCRIPTION
```
diff -u _sources/plutus-core/1.0.0.0/revisions/2.cabal _sources/plutus-core/1.0.0.0/revisions/3.cabal
--- _sources/plutus-core/1.0.0.0/revisions/2.cabal	2022-09-07 15:36:04.563647018 +0200
+++ _sources/plutus-core/1.0.0.0/revisions/3.cabal	2022-09-07 15:36:58.839376550 +0200
@@ -257,7 +257,7 @@
       , cborg                  >= 0.2.6.0   && <0.3
       , composition-prelude    >= 1.1.0.1   && <3.1
       , containers             >= 0.6.2.1   && <0.7
-      , cryptonite             >= 0.29      && <0.30
+      , cryptonite             >= 0.29      && <0.31
       , data-default-class     >= 0.1.2.0   && <0.2
       , deepseq                >= 1.4.4.0   && <1.5
       , dependent-sum-template >= 0.1.0.3   && <0.2
```